### PR TITLE
Add support for mobile properties and screen calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ GA.prototype.track    = proxy('track');
 GA.prototype.identify = proxy('identify');
 GA.prototype.alias    = proxy('alias');
 GA.prototype.page     = proxy('page');
+GA.prototype.screen   = proxy('screen');
 
 /**
  * Proxy the method to classic or universal analytics.
@@ -43,9 +44,11 @@ GA.prototype.page     = proxy('page');
 
 function proxy(method){
   return function(message, fn){
-    var ga = this.settings.serversideClassic ? this.classic: this.universal;
-    return ga[method]
-      ? ga[method].call(ga, message, fn)
-      : setImmediate(fn);
-  }
+    if (this.settings.serversideClassic) {
+      return method === "screen"
+        ? setImmediate(fn)
+        : this.classic[method].call(this.classic, message, fn)
+    }
+    return this.universal[method].call(this.universal, message, fn);
+  };
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -36,6 +36,24 @@ exports.page = function(page, settings){
 };
 
 /**
+ * Map screen msg.
+ *
+ * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#screenView
+ *
+ * @param {Screen} screen
+ * @param {Object} settings
+ * @return {Object}
+ */
+
+exports.screen = function(screen, settings){
+  var ret = createCommonGAForm(screen, settings);
+  ret.cd = screen.name();
+  ret.t = 'screenview';
+
+  return ret;
+};
+
+/**
  * Track.
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#event
@@ -116,15 +134,17 @@ exports.completedOrder = function(track, settings){
  */
 
 function createCommonGAForm(facade, settings){
+  var library = facade.proxy('context.library');
   var cid = hash(facade.userId() || facade.anonymousId());
   var campaign = facade.proxy('context.campaign') || {};
   var options = facade.options('Google Analytics');
   var app = facade.proxy('context.app') || {};
   var screen = facade.proxy('context.screen') || {};
-  var tid = settings.serversideTrackingId;
   var traits = facade.traits();
   var properties = facade.field('properties') || {};
-
+  var trackingId = isMobile(library)
+    ? settings.mobileTrackingId
+    : settings.serversideTrackingId
   if (options && is.string(options.clientId)) cid = options.clientId;
 
   var form = extend(
@@ -132,7 +152,7 @@ function createCommonGAForm(facade, settings){
     metrics(properties, settings)
   );
   form.cid = cid;
-  form.tid = tid;
+  form.tid = trackingId;
   form.v = 1;
 
   // campaign
@@ -149,6 +169,8 @@ function createCommonGAForm(facade, settings){
   // app
   if (app.name) form.an = app.name;
   if (app.version) form.av = app.version;
+  if (app.appId) form.aid = app.appId;
+  if (app.appInstallerId) form.aiid = app.appInstallerId;
 
   if (settings.sendUserId && facade.userId()) form.uid = facade.userId();
   if (facade.userAgent()) form.ua = facade.userAgent();
@@ -208,3 +230,27 @@ function shorten(name, _){
   if (_ = name.match(/^metric(\d+)$/)) return 'cm' + _[1];
   if (_ = name.match(/^dimension(\d+)$/)) return 'cd' + _[1];
 }
+
+/**
+ * Determine whether the request is being made directly on behalf of a
+ * mobile device (iOS, android, Xamarin).
+ *
+ * @param {Object|String} library
+ * @return {Boolean}
+ */
+
+function isMobile(library){
+  if (!library) return false;
+  return contains('ios')
+    || contains('android')
+    || contains('analytics.xamarin');
+
+  function contains(str) {
+    return name().toLowerCase().indexOf(str) !== -1;
+  }
+
+  function name() {
+    return typeof library === 'string' ? library : library.name;
+  }
+}
+

--- a/lib/universal.js
+++ b/lib/universal.js
@@ -91,6 +91,22 @@ GA.prototype.page = function(page, fn){
 };
 
 /**
+ * Screen.
+ *
+ * @param {Screen} screen
+ * @param {Function} callback
+ */
+
+GA.prototype.screen = function (screen, callback) {
+  var payload = mapper.screen(screen, this.settings);
+  return this
+    .post()
+    .type('form')
+    .send(payload)
+    .end(this.handle(callback));
+};
+
+/**
  * Get headers.
  *
  * @return {Object}

--- a/test/fixtures/screen-app.json
+++ b/test/fixtures/screen-app.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "name": "Home",
+    "context": {
+      "app": {
+        "name": "Test App",
+        "version": "1.1",
+        "appId":"com.foo.App",
+        "appInstallerId": "com.android.vending"
+      },
+      "library": {
+        "name": "analytics-iOS",
+        "version": "3.0.0"
+      }
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "tid": "UA-27033709-23",
+    "cd": "Home",
+    "t": "screenview",
+    "v": 1,
+    "an": "Test App",
+    "av": "1.1",
+    "aid": "com.foo.App",
+    "aiid": "com.android.vending"
+  }
+}

--- a/test/fixtures/screen-basic.json
+++ b/test/fixtures/screen-basic.json
@@ -1,0 +1,20 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "name": "Home",
+    "context": {
+      "library": {
+        "name": "analytics-android",
+        "version": "3.0.0"
+      }
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "tid": "UA-27033709-23",
+    "cd": "Home",
+    "t": "screenview",
+    "v": 1
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ describe('Google Analytics', function(){
 
   beforeEach(function(){
     payload = {};
-    universal = { serversideTrackingId: 'UA-27033709-11', serversideClassic: false };
+    universal = { serversideTrackingId: 'UA-27033709-11', mobileTrackingId: 'UA-27033709-23', serversideClassic: false };
     classic = { serversideTrackingId: 'UA-27033709-5', serversideClassic: true };
     settings = {
       universal: universal,
@@ -118,6 +118,16 @@ describe('Google Analytics', function(){
           test.maps('completed-order-cm-cd', settings);
         });
       });
+
+       describe('screen', function(){
+        it('should map basic screen', function(){
+          test.maps('screen-basic', settings);
+        });
+
+        it('should map context.app', function(){
+          test.maps('screen-app', settings);
+        });
+      });
     });
 
     describe('.track()', function(){
@@ -176,6 +186,27 @@ describe('Google Analytics', function(){
           .set(settings)
           .set(json.settings)
           .page(json.input)
+          .sends(json.output)
+          .expects(200, done);
+      });
+    });
+
+    describe('.screen()', function(){
+      it('should get a good response from the API', function(done){
+        var json = test.fixture('screen-basic');
+        test
+          .set(settings)
+          .screen(json.input)
+          .sends(json.output)
+          .expects(200, done);
+      });
+
+      it('should send app info', function(done){
+        var json = test.fixture('screen-app');
+        test
+          .set(settings)
+          .set(json.settings)
+          .screen(json.input)
           .sends(json.output)
           .expects(200, done);
       });


### PR DESCRIPTION
This is a follow-up from a [PR on the old repo](https://github.com/segmentio/integrations/pull/238)... reconfigured to use `mobileTrackingId` for calls from mobile libraries! See that PR for details on why this is important.

Functionally, firing:
![](https://cloudup.com/cOK8_ZshDGu+)

... yields:
![](https://cloudup.com/cXw7cDJTL-d+)

cc/ @amillet89 @ndhoule @segmentio/success 