### PR TITLE
mobile: fall back to server-side tracking ID for compat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,16 @@ var Classic = require('./classic');
  */
 
 var GA = module.exports = integration('Google Analytics')
-  .ensure('settings.serversideTrackingId')
-  .channels(['server'])
+  .channels(['server']);
+
+/**
+ * We require either a server side or mobile tracking ID
+ */
+
+GA.ensure(function(msg, settings){
+  if (settings.serversideTrackingId || settings.mobileTrackingId) return;
+  return this.reject('Must set either serverSide or mobile tracking ID');
+});
 
 /**
  * Initialize

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -143,7 +143,7 @@ function createCommonGAForm(facade, settings){
   var traits = facade.traits();
   var properties = facade.field('properties') || {};
   var trackingId = isMobile(library)
-    ? settings.mobileTrackingId
+    ? settings.mobileTrackingId || settings.serversideTrackingId
     : settings.serversideTrackingId
   if (options && is.string(options.clientId)) cid = options.clientId;
 

--- a/test/fixtures/screen-server-id.json
+++ b/test/fixtures/screen-server-id.json
@@ -1,0 +1,20 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "name": "Home",
+    "context": {
+      "library": {
+        "name": "analytics-android",
+        "version": "3.0.0"
+      }
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "tid": "UA-27033709-11",
+    "cd": "Home",
+    "t": "screenview",
+    "v": 1
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,6 @@ describe('Google Analytics', function(){
   it('should have the correct settings', function(){
     test
       .name('Google Analytics')
-      .ensure('settings.serversideTrackingId')
       .channels(['server']);
   });
 
@@ -40,8 +39,19 @@ describe('Google Analytics', function(){
       test.valid({}, settings.universal);
     });
 
-    it('should be invalid without .serversideTrackingId', function(){
+    it('should still be valid with just .mobileTrackingId', function(){
       delete settings.universal.serversideTrackingId;
+      test.valid({}, settings.universal);
+    });
+
+    it('should still be valid with just .serversideTrackingId', function(){
+      delete settings.universal.mobileTrackingId;
+      test.valid({}, settings.universal);
+    });
+
+    it('should be invalid without .serversideTrackingId or .mobileTrackingId', function(){
+      delete settings.universal.serversideTrackingId;
+      delete settings.universal.mobileTrackingId;
       test.invalid({}, settings.universal);
     });
   });
@@ -126,6 +136,11 @@ describe('Google Analytics', function(){
 
         it('should map context.app', function(){
           test.maps('screen-app', settings);
+        });
+
+        it('should fall back to server-side id', function(){
+          delete settings.mobileTrackingId;
+          test.maps('screen-server-id', settings);
         });
       });
     });


### PR DESCRIPTION
A few customers were already sending *events* to GA *web* properties from mobile (ie. weren't bundling the SDK). The prior update (adding screen and using mobile tracking ID) didn't account for those customers and this PR fixes that. 

@f2prateek 