### PR TITLE
map locale to user language

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -143,14 +143,16 @@ exports.completedOrder = function(track, settings){
 
 function createCommonGAForm(facade, settings){
   var library = facade.proxy('context.library');
+  var trackingId = isMobile(library) ? settings.mobileTrackingId || settings.serversideTrackingId : settings.serversideTrackingId;
   var cid = hash(facade.userId() || facade.anonymousId());
   var campaign = facade.proxy('context.campaign') || {};
-  var options = facade.options('Google Analytics');
-  var app = facade.proxy('context.app') || {};
-  var screen = facade.proxy('context.screen') || {};
-  var traits = facade.traits();
   var properties = facade.field('properties') || {};
-  var trackingId = isMobile(library) ? settings.mobileTrackingId || settings.serversideTrackingId : settings.serversideTrackingId;
+  var screen = facade.proxy('context.screen') || {};
+  var locale = facade.proxy('context.locale');
+  var app = facade.proxy('context.app') || {};
+  var traits = facade.traits();
+
+  var options = facade.options('Google Analytics');
   if (options && is.string(options.clientId)) cid = options.clientId;
 
   var form = extend(
@@ -167,10 +169,13 @@ function createCommonGAForm(facade, settings){
   if (campaign.medium) form.cm = campaign.medium;
   if (campaign.content) form.cc = campaign.content;
 
-  //screen
+  // screen
   if (screen.height && screen.width) {
     form.sr = fmt('%sx%s', screen.width, screen.height);
   }
+
+  // locale
+  if (locale) form.ul = locale;
 
   // app
   if (app.name) form.an = app.name;

--- a/test/fixtures/page-locale.json
+++ b/test/fixtures/page-locale.json
@@ -1,0 +1,23 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "name": "Google Analytics",
+    "properties": {
+      "url": "https://segment.io/docs/integrations/google-analytics/"
+    },
+    "context": {
+      "locale": "en-us"
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "dh": "segment.io",
+    "tid": "UA-27033709-11",
+    "dp": "/docs/integrations/google-analytics/",
+    "dt": "Google Analytics",
+    "t": "pageview",
+    "ul": "en-us",
+    "v": 1
+  }
+}

--- a/test/universal.js
+++ b/test/universal.js
@@ -39,6 +39,10 @@ describe('Google Analytics :: Universal', function(){
         test.maps('page-screen', settings);
       });
 
+      it('should map context.locale', function(){
+        test.maps('page-locale', settings);
+      });
+
       it('should map page with custom dimensions and metrics', function(){
         test.maps('page-cm-cd', settings);
       });


### PR DESCRIPTION
Their `user language (ul)` [parameter](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ul) takes a locale string. Seems like something we should definitely map directly!

See: https://trello.com/c/3Fs6yJdH/28-fix-ga-pass-user-s-language