### PR TITLE
Ensure string value prior to parsing url

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -198,6 +198,8 @@ function createCommonGAForm(facade, settings){
 
 function createPageDataForm(facade, form){
   var url = facade.proxy('properties.url') || facade.proxy('context.page.url');
+  if (!is.string(url)) return form; 
+
   var parsed = parse(url || '');
   if (parsed.hostname) form.dh = parsed.hostname;
   if (parsed.path) form.dp = parsed.path;


### PR DESCRIPTION
Fixes this issue.

```
"TypeError: Parameter 'url' must be a string, not object\n    at Url.parse (url.js:107:11)\n    at urlParse (url.js:101:5)\n    at createPageDataForm (/srv/integration-google-analytics/current/lib/mapper.js:201:16)\n    at Object.exports.track (/srv/integration-google-analytics/current/lib/mapper.js:69:16)\n    at Integration.GA.track (/srv/integration-google-analytics/current/lib/universal.js:27:24)\n    at Integration.integration.track (/srv/integration-google-analytics/current/node_modules/segmentio-integration/lib/wrap-methods.js:57:18)\n    at Integration.<anonymous> (/srv/integration-google-analytics/current/lib/index.js:59:25)\n    at Integration.integration.track (/srv/integration-google-analytics/current/node_modules/segmentio-integration/lib/wrap-methods.js:57:18)\n    at Worker.process (/usr/local/lib/node_modules/@segment/integration-worker/lib/worker.js:110:26)\n    at Worker.onmessage (/usr/local/lib/node_modules/@segment/integration-worker/lib/worker.js:190:8
```

cc: @sperand-io 