### PR TITLE
adds validation for context.app.name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,17 @@ GA.ensure(function(msg, settings){
 });
 
 /**
+ * GA requires application name with App/Screen tracking
+ * https://developers.google.com/analytics/devguides/collection/analyticsjs/screens
+ */
+
+GA.ensure(function(msg, _){
+  if ('screen' != msg.type()) return;
+  if (msg.proxy('context.app.name')) return;
+  return this.reject('context.app.name required');
+});
+
+/**
  * Initialize
  *
  * @api private
@@ -51,10 +62,10 @@ GA.prototype.screen = proxy('screen');
 
 function proxy(method){
   return function(message, fn){
-    var receiver = this.settings.serversideClassic 
-      ? this.classic 
+    var receiver = this.settings.serversideClassic
+      ? this.classic
       : this.universal;
-      
+
     return 'function' === typeof receiver[method]
       ? receiver[method](message, fn)
       : setImmediate(fn);

--- a/test/index.js
+++ b/test/index.js
@@ -46,5 +46,22 @@ describe('Google Analytics', function(){
       delete settings.mobileTrackingId;
       test.invalid({}, settings);
     });
+
+    it('should be valid with context.app.name', function(){
+      test.valid({
+        type: 'screen',
+        context: {
+          app: {
+            name: 'foo'
+          }
+        }
+      }, settings);
+    });
+
+    it('should be invalid without context.app.name', function(){
+      test.invalid({
+        type: 'screen'
+      }, settings);
+    });
   });
 });


### PR DESCRIPTION
This will return an error when `context.app.name` isn't passed through a server-side `.screen()` call. GA requires that `an` : [Application Name](https://developers.google.com/analytics/devguides/collection/analyticsjs/screens) be passed through `.screen()` calls. 

@sperand-io :eyes: 