### PR TITLE
Generates user agent

### DIFF
--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -579,6 +579,10 @@ function createCommonGAForm(facade, settings) {
   var app = facade.proxy('context.app') || {};
   var traits = facade.traits();
   var options = facade.options('Google Analytics');
+  var osName = facade.proxy('context.os.name');
+  var osVersion = facade.proxy('context.os.version');
+  var deviceModel = facade.proxy('context.device.model');
+  var deviceManufacturer = facade.proxy('context.device.manufacturer');
 
   if (options && is.string(options.clientId)) cid = options.clientId;
 
@@ -611,8 +615,23 @@ function createCommonGAForm(facade, settings) {
   if (app.appInstallerId) form.aiid = app.appInstallerId;
 
   if (settings.sendUserId && facade.userId()) form.uid = facade.userId();
-  if (facade.userAgent()) form.ua = facade.userAgent();
   if (facade.ip()) form.uip = facade.ip();
+
+  /**
+ * GA parses userAgent to compute device type.
+ * Generates a user agent if one is not provided for all calls only while context is present.
+ *
+ * Expected format:
+ * Mozilla/[version] ([system and browser information]) [platform] ([platform details]) [extensions]
+
+ * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ua
+ */
+
+  if (facade.userAgent()) {
+    form.ua = facade.userAgent();
+  } else if(osName && osVersion && deviceModel && deviceManufacturer && locale) {
+    form.ua = "Segment/1.0 (" + osName + "; CPU " + deviceModel +"; " + locale + ") " + deviceManufacturer + "; " + "Version " + osVersion;
+  }
 
   return form;
 }

--- a/test/fixtures/page-app.json
+++ b/test/fixtures/page-app.json
@@ -11,7 +11,17 @@
       "app": {
         "name": "web",
         "version": "1.1"
-      }
+      },
+      "device": {
+        "manufacturer": "Apple",
+        "model": "iPhone8,1",
+        "type": "ios"
+      },
+      "os": {
+        "name": "iPhone OS",
+        "version": "9.3"
+      },
+      "locale": "en-US"
     }
   },
   "output": {
@@ -23,6 +33,8 @@
     "an": "web",
     "av": "1.1",
     "t": "pageview",
-    "v": 1
+    "v": 1,
+    "ul": "en-US",
+    "ua": "Segment/1.0 (iPhone OS; CPU iPhone8,1; en-US) Apple; Version 9.3"
   }
 }

--- a/test/fixtures/screen-app.json
+++ b/test/fixtures/screen-app.json
@@ -13,7 +13,8 @@
       "library": {
         "name": "analytics-iOS",
         "version": "3.0.0"
-      }
+      },
+      "userAgent": "Dalvik/2.1.0 (Linux; U; Android 5.0; SM-G900V Build/LRX21T)"
     }
   },
   "output": {
@@ -25,6 +26,7 @@
     "an": "Test App",
     "av": "1.1",
     "aid": "com.foo.App",
-    "aiid": "com.android.vending"
+    "aiid": "com.android.vending",
+    "ua" : "Dalvik/2.1.0 (Linux; U; Android 5.0; SM-G900V Build/LRX21T)"
   }
 }

--- a/test/fixtures/track-app.json
+++ b/test/fixtures/track-app.json
@@ -12,6 +12,10 @@
       "app": {
         "name": "web",
         "version": "1.1"
+      },
+      "os": {
+        "name": "iPhone OS",
+        "version": "9.3"
       }
     }
   },

--- a/test/universal.js
+++ b/test/universal.js
@@ -155,6 +155,16 @@ describe('Google Analytics :: Universal', function() {
         .sends(json.output)
         .expects(200, done);
     });
+
+    it('should not send ua if device is not present', function(done) {
+      var json = test.fixture('track-app');
+      test
+        .set(settings)
+        .set(json.settings)
+        .track(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
   });
 
   describe('.page()', function() {
@@ -176,6 +186,16 @@ describe('Google Analytics :: Universal', function() {
         .sends(json.output)
         .expects(200, done);
     });
+
+    it('should create ua without userAgent present', function(done) {
+      var json = test.fixture('page-app');
+      test
+        .set(settings)
+        .set(json.settings)
+        .page(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
   });
 
   describe('.screen()', function() {
@@ -189,6 +209,16 @@ describe('Google Analytics :: Universal', function() {
     });
 
     it('should send app info', function(done) {
+      var json = test.fixture('screen-app');
+      test
+        .set(settings)
+        .set(json.settings)
+        .screen(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+
+    it('should send ua value', function(done) {
       var json = test.fixture('screen-app');
       test
         .set(settings)


### PR DESCRIPTION
GA parses userAgent to compute device type. This will generate a user agent (`ua`) value if one is not provided for all calls if the necessary context is present.

Expected format:
`Mozilla/[version] ([system and browser information]) [platform] ([platform details]) [extensions]`

https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ua